### PR TITLE
Update WebDriverManager.cls - avoid duplicated web query to get latest driver version

### DIFF
--- a/src/WebDriverManager.cls
+++ b/src/WebDriverManager.cls
@@ -145,7 +145,7 @@ Private Function AlignDriverWithBrowser(ByVal browser As svbaBrowser, ByVal driv
     
     dverCompat = GetCompatibleDriverVersion(browser, bverInstalled)
     
-    If Not IsInstalledDriverCompatible(browser, driverPath) Then
+    If Not IsInstalledDriverCompatible(browser, driverPath, bverInstalled, dverCompat) Then
         DownloadAndInstallDriver browser, dverCompat, driverPath
         respStr = "The latest " & BrowserNameStr(browser) & " Webdriver was installed."
     Else
@@ -169,9 +169,10 @@ Public Function AlignFirefoxDriverWithBrowser(Optional ByVal driverPath As Strin
     AlignFirefoxDriverWithBrowser = AlignDriverWithBrowser(svbaBrowser.Firefox, driverPath)
 End Function
 
-Public Function IsInstalledDriverCompatible(ByVal browser As svbaBrowser, Optional ByVal driverPath) As Boolean
+Public Function IsInstalledDriverCompatible(ByVal browser As svbaBrowser, Optional ByVal driverPath, _
+                                                        Optional bverInstalled, Optional dverCompat) As Boolean
     Dim fso As New IWshRuntimeLibrary.FileSystemObject, clevel As svbaCompatibility
-    Dim bverInstalled As String, dverinstalled As String, dverCompat As String
+    Dim dverinstalled As String
     
     If IsMissing(driverPath) Then
         Select Case browser
@@ -191,14 +192,14 @@ Public Function IsInstalledDriverCompatible(ByVal browser As svbaBrowser, Option
         Exit Function
     End If
     
-    bverInstalled = Me.GetInstalledBrowserVersion(browser)
+    If IsMissing(bverInstalled) Then bverInstalled = Me.GetInstalledBrowserVersion(browser)
     If bverInstalled = "browser not installed" Then
         IsInstalledDriverCompatible = False
         Exit Function
     End If
     
     dverinstalled = Me.GetInstalledDriverVersion(browser, driverPath)
-    dverCompat = Me.GetCompatibleDriverVersion(browser, bverInstalled)
+    If IsMissing(dverCompat) Then dverCompat = Me.GetCompatibleDriverVersion(browser, bverInstalled)
     clevel = Me.CheckCompatibilityLevel(dverinstalled, dverCompat)
     
     If clevel >= mMinCompatibilityLevel Then


### PR DESCRIPTION
With "checkDriverBrowserVersionAlignment = True" I noticed that every time I launched my macro, it sent TWO identical consecutive web queries to "https://msedgedriver.azureedge.net/LATEST_STABLE/[num]", wasting about 0.3 seconds on the second query.

The duplication was because the GetCompatibleDriverVersion proc (containing the above web query) is called one time in AlignDriverWithBrowser a second (wasted) time in the called subproc IsInstalledDriverCompatible.

This mod avoids the duplicated query in IsInstalledDriverCompatible, (only) if already done before.